### PR TITLE
add related link and image content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,40 @@
+<!-- PROJECT SHIELDS -->
+
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues-open][issues-open-shield]][issues-url]
+[![Issues-closed][issues-closed-shield]][issues-url]
+[![Contributors][contributors-shield]][contributors-url]
+[![Framework][badge-framework]][framework-url]
+[![contributions welcome][contributions-welcome]][issues-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<p align="center">
+  <a href="https://github.com/root-code-software/github-issue-templates">
+	  <img src="https://user-images.githubusercontent.com/67714964/169252140-e5b60ea6-36ff-4cd6-9888-b1c02377fed6.jpg" alt="logo"/>
+  </a>
+
+  <h1 align="center">
+	 Github-Issue-Templates
+ 
+  </h1>
+
+  <p align="center">
+    Example Subtitle
+    <br />
+	  🖊️
+    <a href="https://">Read the article</a>
+    🐞
+    <a href="https://github.com/root-code-software/github-issue-templates/issues">Report a Bug</a>
+    🙋‍♂️
+    <a href="https://github.com/root-code-software/github-issue-templates/issues">Request Feature</a>
+  </p>
+</p>
+
 ## A collection of GitHub issue and pull request templates
 
-*Update*: GitHub now also supports [multiple issue templates](https://help.github.com/articles/about-issue-and-pull-request-templates/).
+_Update_: GitHub now also supports [multiple issue templates](https://help.github.com/articles/about-issue-and-pull-request-templates/).
 
 ~~GitHub finally supports [issue template](https://github.com/blog/2111-issue-and-pull-request-templates).~~
 
@@ -17,14 +51,30 @@
 
 Find your issue/PR templates, and just grab and go.
 
-*Inspired by excellent GitHub projects that use issue and pull request templates.*
+_Inspired by excellent GitHub projects that use issue and pull request templates._
 
 Templates here are either copied from or modified based on real projects on GitHub.
 
-*See also [awesome-github-templates](https://github.com/devspace/awesome-github-templates) for more examples in real projects :tada:*
+_See also [awesome-github-templates](https://github.com/devspace/awesome-github-templates) for more examples in real projects :tada:_
 
 ## License
 
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Steve Mao](https://github.com/stevemao) has waived all copyright and related or neighboring rights to this work.
+
+<!-- MARKDOWN LINKS & IMAGES -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/root-code-software/github-issue-templates?style=for-the-badge
+[contributors-url]: https://github.com/root-code-software/github-issue-templates/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/root-code-software/github-issue-templates?style=for-the-badge
+[forks-url]: https://github.com/root-code-software/github-issue-templates/network/members
+[stars-shield]: https://img.shields.io/github/stars/root-code-software/github-issue-templates?style=for-the-badge
+[stars-url]: https://github.com/root-code-software/github-issue-templates/stargazers
+[issues-open-shield]: https://img.shields.io/github/issues/root-code-software/github-issue-templates?style=for-the-badge
+[issues-url]: https://github.com/root-code-software/github-issue-templates/issues
+[issues-closed-shield]: https://img.shields.io/github/issues-closed/root-code-software/github-issue-templates?style=for-the-badge
+[badge-framework]: https://img.shields.io/badge/framework-here-9cf?style=for-the-badge
+[framework-url]: https://google.com
+[contributions-welcome]: https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=for-the-badge
+[badge-license]: https://img.shields.io/:license-mit-blue.svg?style=for-the-badge


### PR DESCRIPTION
Issue Title: Add More Content - Github-Issue-Templates #130

Added related link and content.

![fix](https://user-images.githubusercontent.com/67714964/169253141-fd02db21-a788-4421-9df0-a8bb5760bc6b.jpg)

